### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,6 @@ Join the conversation! Other design considerations and details can be found on t
 
 .. |Build Status| image:: https://travis-ci.org/mekarpeles/pypc.png
 
-.. |Wheel Status| image:: https://pypip.in/wheel/pypc/badge.svg
+.. |Wheel Status| image:: https://img.shields.io/pypi/wheel/pypc.svg
     :target: https://pypi.python.org/pypi/pypc/
     :alt: Wheel Status


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pypc))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pypc`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.